### PR TITLE
Pin version of VTK that is compatible with pinned version of pyvista

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 https://github.com/tussedrotten/pylie/archive/v1.0.1.zip
-numpy
-opencv-python
-pyvista
-pytest
-scipy
+numpy==1.26.4
+opencv-python==4.9.0.80
+pyvista==0.44.2
+pytest==8.1.1
+scipy==1.12.0
+vtk==9.3.0


### PR DESCRIPTION
Hilsen copilot:

> PyVista 0.43.4 is known to have compatibility issues with certain versions of VTK. To resolve this, you can try pinning VTK to a version that is compatible with PyVista 0.43.4.

> Based on the information available, VTK 9.3.0 is a compatible version for PyVista 0.43.4